### PR TITLE
fixed the typo and added the code of conduct link in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# **Test Project for GRPC Graceful Shutdown Issue**
+
+This project is a test suite designed to identify and troubleshoot issues related to GRPC (Google Remote Procedure Call) graceful shutdown.
+
+## **Background**
+
+GRPC is a high-performance open-source framework that allows developers to build distributed systems and microservices. Graceful shutdown is a critical feature of any server, as it ensures that all pending requests are completed before the server shuts down, thereby minimizing data loss and disruption.
+
+However, there are certain scenarios where GRPC servers may fail to shut down gracefully, such as when there are slow client connections or long-running requests. These issues can result in data loss or other problems.
+
+## **Purpose**
+
+The purpose of this project is to create a test suite that simulates various scenarios that may cause GRPC servers to fail to shut down gracefully. By running these tests, we can identify and troubleshoot any issues that arise and improve the reliability and stability of GRPC-based systems.
+
+## **Installation**
+
+To install and run the test suite, follow these steps:
+
+- Clone the repository to your local machine
+- Install the necessary dependencies (e.g., GRPC, testing frameworks, etc.)
+- Run the test suite using Golang's built-in testing framework, navigate to the project directory in your terminal and run the command 'go test'."
+
+## **Usage**
+
+To use the test suite, simply run the tests and observe the results. The tests should simulate various scenarios where GRPC servers may fail to shut down gracefully, such as slow client connections, long-running requests, etc.
+
+If any issues are identified, please report them to the project maintainers so that they can be addressed promptly.
+
+## **Code of Conduct**
+
+You can access the code of conduct from here: [Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct)
+
+## **Contributors**
+
+- [Didier Roche-Tolomelli](https://github.com/didrocks)
+
+- [Jean-Baptiste Lallement](https://github.com/jibel)
+
+If you wish to contribute to the project, please fork the repository and submit a pull request with your changes.


### PR DESCRIPTION
I sent this [PR](https://github.com/ubuntu/grpcstop/pull/1) but there was a typo mistake that I fixed and I also added the conduct of code link in the readme file so that anyone can access it.